### PR TITLE
Update Misreferenced Variable

### DIFF
--- a/src/BaseKit/Builder/Writer/ApiWriter.php
+++ b/src/BaseKit/Builder/Writer/ApiWriter.php
@@ -262,7 +262,7 @@ class ApiWriter implements WriterInterface
     public function writeSite(SiteBuilder $siteBuilder)
     {
         if ($siteBuilder->getSiteRef() === 0) {
-            $siteRef = $this->createSite($site);
+            $siteRef = $this->createSite($siteBuilder);
         }
 
         foreach ($siteBuilder->getPages() as $page) {


### PR DESCRIPTION
Pass the correct `$siteBuilder` instead of `$site` to `createSite()`. Fixes undefined variable notice, and required instanceof fatal error.